### PR TITLE
Fix for clothing base colors

### DIFF
--- a/ACViewer/Model/Setup.cs
+++ b/ACViewer/Model/Setup.cs
@@ -77,7 +77,7 @@ namespace ACViewer.Model
                 {
                     gfxObjID = _setup.Parts[i];
                     gfxObj = new GfxObj(gfxObjID, false);
-                    gfxObj.LoadTextures(null, null);
+                    gfxObj.LoadTextures(null, customPaletteColors);
                     gfxObj.BuildPolygons();
                 }
 


### PR DESCRIPTION
This fixing an issue with the display of a ClothingTable model where only the palette changed. Previously, the colors from the updated palette(s) would not be applied to the displayed model.