### PR TITLE
keep track of uncached textures for dispose

### DIFF
--- a/ACViewer/Render/TextureCache.cs
+++ b/ACViewer/Render/TextureCache.cs
@@ -24,6 +24,8 @@ namespace ACViewer.Render
 
         public static Dictionary<uint, Texture2D> Textures { get; set; }
 
+        public static List<Texture2D> Uncached { get; set; }
+
         public static bool UseMipMaps { get; set; }
 
         static TextureCache()
@@ -33,16 +35,26 @@ namespace ACViewer.Render
 
         public static void Init(bool dispose = true)
         {
-            if (dispose && Textures != null)
+            if (dispose)
             {
-                foreach (var texture in Textures.Values)
-                    texture.Dispose();
+                if (Textures != null)
+                {
+                    foreach (var texture in Textures.Values)
+                        texture.Dispose();
+                }
+                
+                if (Uncached != null)
+                {
+                    foreach (var texture in Uncached)
+                        texture.Dispose();
+                }
             }
 
             GfxObjCache.Init();
             SetupCache.Init();
 
             Textures = new Dictionary<uint, Texture2D>();
+            Uncached = new List<Texture2D>();
         }
 
         private static Texture2D LoadTexture(uint textureID, bool useDummy = false, Surface surface = null, Dictionary<int, uint> customPaletteColors = null)
@@ -435,6 +447,8 @@ namespace ACViewer.Render
 
             if (useCache)
                 Textures.Add(textureID, texture);
+            else
+                Uncached.Add(texture);
 
             return texture;
         }


### PR DESCRIPTION
Dispose needs to be explicitly called on Texture2D to free GPU ram

When cycling through a Clothing with many colors, such as 0x10000006, the system RAM still skyrockets according to Task Manager. However, according to heap profiles, actual used memory is only a tiny fraction of what Task Manager reports. I'm guessing if a GC cleanup was forced, Task Manager might show the actual used memory afterwards.