### PR TITLE
Fix to not load palettes from dat FileCache for ClothingBase

### DIFF
--- a/ACViewer/Render/TextureCache.cs
+++ b/ACViewer/Render/TextureCache.cs
@@ -293,7 +293,13 @@ namespace ACViewer.Render
         {
             var colors = GetColors(texture);
             
-            var palette = DatManager.PortalDat.ReadFromDat<Palette>((uint)texture.DefaultPaletteId);
+            // Load a fresh version of the palette. If we call "ReadFromDat", it will modify the value in the FileCache
+            var datReader = DatManager.PortalDat.GetReaderForFile((uint)texture.DefaultPaletteId);
+            var palette = new Palette();
+            using (var memoryStream = new MemoryStream(datReader.Buffer))
+            using (var reader = new BinaryReader(memoryStream))
+                palette.Unpack(reader);
+
 
             // Apply any custom palette colors, if any, to our loaded palette (note, this may be all of them!)
             if (texture.CustomPaletteColors.Count > 0)


### PR DESCRIPTION
When loading a palette from the dat FileCache for use with ClothingBase, we will copy the color list rather than accessing it directly. This prevents any custom color changes saving back to the dat FileCache and propagating to new items.

Example: 
- Load ClothingTable item 0x1000061E
- First entry will auto select, Tumerok will auto load with blue armor, purple skin, brown legs/boots.
- Select PaletteTemplate "Silver - 20". Tumerok should load with grey armor, red skin, and green legs/boots. Previously would only change skin tone.

