### PR TITLE
fix GfxObj positioning with SimpleSetup

### DIFF
--- a/ACViewer/FileTypes/Texture.cs
+++ b/ACViewer/FileTypes/Texture.cs
@@ -28,6 +28,9 @@ namespace ACViewer.FileTypes
 
             treeView.Items.AddRange(new List<TreeNode>() { unknown, width, height, format, size });
 
+            if (_texture.DefaultPaletteId != null)
+                treeView.Items.Add(new TreeNode($"DefaultPalette: {_texture.DefaultPaletteId:X8}"));
+
             return treeView;
         }
     }

--- a/ACViewer/MapViewer.cs
+++ b/ACViewer/MapViewer.cs
@@ -61,6 +61,8 @@ namespace ACViewer
 
             Highlight = new Texture2D(GraphicsDevice, 1, 1);
             Highlight.SetData(new Microsoft.Xna.Framework.Color[1] { Microsoft.Xna.Framework.Color.Red });
+
+            Font = GameView.Instance.Content.Load<SpriteFont>("Fonts/Consolas");
         }
 
         public void Init()
@@ -261,6 +263,8 @@ namespace ACViewer
             spriteBatch.End();
 
             DrawHighlight();
+
+            DrawHUD();
         }
 
         public static Microsoft.Xna.Framework.Rectangle[] Highlight_Sides = new Microsoft.Xna.Framework.Rectangle[4]
@@ -303,6 +307,26 @@ namespace ACViewer
             }
 
             spriteBatch.End();
+        }
+
+        // text rendering
+
+        public SpriteFont Font;
+
+        public void DrawHUD()
+        {
+            var landblock = ImagePos / 8;
+
+            if (landblock.X >= 0 && landblock.X < 255 && landblock.Y >= 0 && landblock.Y < 255)
+            {
+                landblock.Y = 255 - landblock.Y;
+
+                var textPos = new Vector2(GraphicsDevice.Viewport.Width - 42, 10);
+
+                spriteBatch.Begin(SpriteSortMode.Deferred, null, SamplerState.LinearClamp);
+                spriteBatch.DrawString(Font, $"{(int)landblock.X:X2}{(int)landblock.Y:X2}", textPos, Microsoft.Xna.Framework.Color.White);
+                spriteBatch.End();
+            }
         }
     }
 }

--- a/ACViewer/Render/Buffer.cs
+++ b/ACViewer/Render/Buffer.cs
@@ -124,8 +124,12 @@ namespace ACViewer.Render
                 var part = setup.Parts[i];
                 var vertices = part.VertexArray;
 
-                var frame = obj.PartArray.Parts[i].PhysicsPart.Pos;
+                var frame = setup._setup.Id != 0 ? obj.PartArray.Parts[i].PhysicsPart.Pos : obj.PhysicsObj.Position;
+
                 var transform = frame.ToXna();
+
+                if (i < setup._setup.DefaultScale.Count)
+                    transform = Matrix.CreateScale(setup._setup.DefaultScale[i].ToXna()) * transform;
 
                 foreach (var polygon in part.Polygons)
                 {


### PR DESCRIPTION
This fixes some GfxObjs being positioned incorrectly in the world

This can be seen in 5756FFFF, with the large staircase being positioned off into the void, instead of in the large center room.

This can also be seen 03E1FFFF, with the circular staircase also being positioned off into the void, instead of in the nearby room

This was caused when 0x1 GfxObjs are loaded directly, without a 0x2 Setup. The world position information is stored in a slightly different location in that instance.

A few other random updates:

- Objects are now scaled correctly if they contain a non-default scale
- The world map viewer now shows the landblock ID that is currently being hovered over
- The texture data viewer now shows DefaultPalette info, if applicable
