### PR TITLE
Fix crash loading some Clothing Table entries

### DIFF
--- a/ACViewer/Model/Setup.cs
+++ b/ACViewer/Model/Setup.cs
@@ -69,7 +69,7 @@ namespace ACViewer.Model
             {
                 GfxObj gfxObj;
 
-                if (objDesc.PartChanges.TryGetValue((uint)i, out var partChange))
+                if (objDesc.PartChanges != null && objDesc.PartChanges.TryGetValue((uint)i, out var partChange))
                 {
                     gfxObj = new GfxObj(partChange.NewGfxObjId, false);
 


### PR DESCRIPTION
Ensure the Clothing Table has ClothingBaseEffects (PartChanges) before trying to load it (e.g. 100000AF)