### PR TITLE
Better handling of Surface.Type = BASE1_SOLID (solid color surfaces)

### DIFF
--- a/ACViewer/ACViewer.csproj
+++ b/ACViewer/ACViewer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon />
     <StartupObject />

--- a/ACViewer/ACViewer.csproj.user
+++ b/ACViewer/ACViewer.csproj.user
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+  <ItemGroup>
+    <Compile Update="Extensions\ColorDialogEx.cs">
+      <SubType>Component</SubType>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/ACViewer/Render/TextureCache.cs
+++ b/ACViewer/Render/TextureCache.cs
@@ -453,8 +453,10 @@ namespace ACViewer.Render
                     var r = (surface.ColorValue >> 16) & 0xFF;
                     var g = (surface.ColorValue >> 8) & 0xFF;
                     var b = surface.ColorValue & 0xFF;
-                    a = 0;
-                    swatch.SetDataAsync(new Microsoft.Xna.Framework.Color[] { new Microsoft.Xna.Framework.Color(r, g, b, a) });
+
+                    if (surface.Translucency == 1) a = 0;
+
+                    swatch.SetDataAsync(new Microsoft.Xna.Framework.Color[] { new Microsoft.Xna.Framework.Color(Convert.ToByte(r), Convert.ToByte(g), Convert.ToByte(b), Convert.ToByte(a)) });
                     return swatch;
                 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
   only:
   - master
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration:
 - Release
 - Debug


### PR DESCRIPTION
Updated to .NET6, to maintain compatibility with latest ACE version.

For BASE1_SOLID surface, see Setup 02000359. Previously, the Bael'Zharon model would have the alpha set to 0. Also, the color was generated using Int32s which was throwing some issues with the actual color values, so converted these to Bytes which generates the proper color value.