### PR TITLE
add support for surface translucency in texture loader / cache

### DIFF
--- a/ACViewer/Render/TextureCache.cs
+++ b/ACViewer/Render/TextureCache.cs
@@ -139,7 +139,7 @@ namespace ACViewer.Render
 
                     case SurfacePixelFormat.PFID_A8R8G8B8:
                         ConvertToBGRA(data);
-                        if (surface.Translucency > 0)
+                        if (surface != null && surface.Translucency > 0)
                             PremultiplyAlpha(data, 1.0f - surface.Translucency);
                         break;
                 }
@@ -500,7 +500,7 @@ namespace ACViewer.Render
         {
             //Console.WriteLine($"-> GetTexture({textureID:X8})");
 
-            var texturePalette = new TextureChanges(textureID, surface.Translucency, paletteChanges);
+            var texturePalette = new TextureChanges(textureID, surface?.Translucency ?? 0.0f, paletteChanges);
 
             if (useCache && Textures.TryGetValue(texturePalette, out var cached))
                 return cached;

--- a/ACViewer/Render/TextureCache.cs
+++ b/ACViewer/Render/TextureCache.cs
@@ -23,7 +23,7 @@ namespace ACViewer.Render
         public static GraphicsDevice GraphicsDevice => GameView.Instance.GraphicsDevice;
         public static SpriteBatch SpriteBatch => GameView.Instance.SpriteBatch;
 
-        public static Dictionary<TexturePalette, Texture2D> Textures { get; set; }
+        public static Dictionary<TextureChanges, Texture2D> Textures { get; set; }
 
         public static List<Texture2D> Uncached { get; set; }
 
@@ -54,7 +54,7 @@ namespace ACViewer.Render
             GfxObjCache.Init();
             SetupCache.Init();
 
-            Textures = new Dictionary<TexturePalette, Texture2D>();
+            Textures = new Dictionary<TextureChanges, Texture2D>();
             Uncached = new List<Texture2D>();
         }
 
@@ -138,7 +138,9 @@ namespace ACViewer.Render
                         return _tex;
 
                     case SurfacePixelFormat.PFID_A8R8G8B8:
-                        ConvertToABGR(data);
+                        ConvertToBGRA(data);
+                        if (surface.Translucency > 0)
+                            PremultiplyAlpha(data, 1.0f - surface.Translucency);
                         break;
                 }
             }
@@ -291,14 +293,20 @@ namespace ACViewer.Render
             return rgba;
         }
 
-        private static void ConvertToABGR(byte[] argb)
+        private static void ConvertToBGRA(byte[] rgba)
         {
-            for (var i = 0; i < argb.Length; i += 4)
+            for (var i = 0; i < rgba.Length; i += 4)
             {
-                var tmp = argb[i];
-                argb[i] = argb[i + 2];
-                argb[i + 2] = tmp;
+                var tmp = rgba[i];
+                rgba[i] = rgba[i + 2];
+                rgba[i + 2] = tmp;
             }
+        }
+
+        private static void PremultiplyAlpha(byte[] bgra, float alpha)
+        {
+            for (var i = 3; i < bgra.Length; i += 4)
+                bgra[i] = (byte)(bgra[i] * alpha);
         }
 
         private static byte[] IndexToColor(ACE.DatLoader.FileTypes.Texture texture, bool isClipMap = false, PaletteChanges paletteChanges = null)
@@ -492,7 +500,7 @@ namespace ACViewer.Render
         {
             //Console.WriteLine($"-> GetTexture({textureID:X8})");
 
-            var texturePalette = new TexturePalette(textureID, paletteChanges);
+            var texturePalette = new TextureChanges(textureID, surface.Translucency, paletteChanges);
 
             if (useCache && Textures.TryGetValue(texturePalette, out var cached))
                 return cached;

--- a/ACViewer/Render/TextureChanges.cs
+++ b/ACViewer/Render/TextureChanges.cs
@@ -4,20 +4,25 @@ using ACViewer.Model;
 
 namespace ACViewer.Render
 {
-    public class TexturePalette: IEquatable<TexturePalette>
+    public class TextureChanges: IEquatable<TextureChanges>
     {
         public uint TextureId { get; set; }   // 0x6 texture file id
+        public float Translucency { get; set; }
         public PaletteChanges PaletteChanges { get; set; } 
 
-        public TexturePalette(uint textureId, PaletteChanges paletteChanges = null)
+        public TextureChanges(uint textureId, float translucency = 0.0f, PaletteChanges paletteChanges = null)
         {
             TextureId = textureId;
+            Translucency = translucency;
             PaletteChanges = paletteChanges;
         }
 
-        public bool Equals(TexturePalette tp)
+        public bool Equals(TextureChanges tp)
         {
             if (TextureId != tp.TextureId)
+                return false;
+
+            if (Translucency != tp.Translucency)
                 return false;
 
             if (PaletteChanges == null && tp.PaletteChanges == null)
@@ -37,6 +42,8 @@ namespace ACViewer.Render
             int hash = 0;
 
             hash = (hash * 397) ^ TextureId.GetHashCode();
+            
+            hash = (hash * 397) ^ Translucency.GetHashCode();
 
             if (PaletteChanges != null)
                 hash = (hash * 397) ^ PaletteChanges.GetHashCode();


### PR DESCRIPTION
Test case:
Setup: 0x020016A8
GfxObj: 0x01003F83
Surface: 0x08001347

![image](https://github.com/ACEmulator/ACViewer/assets/8909245/7055fddc-01c5-4ebd-b7f1-6b941251f66e)

Thanks to @OptimShi for reporting this issue!