### PR TITLE
Add browser-style back/forward navigation with context menus

### DIFF
--- a/ACViewer/History.cs
+++ b/ACViewer/History.cs
@@ -3,38 +3,128 @@
 namespace ACViewer
 {
     /// <summary>
-    /// DID history
+    /// DID history - browser-style navigation with back/forward support
     /// </summary>
     public class History
     {
         private static readonly int MaxSize = 50;
-        
+
         private readonly List<uint> DID = new List<uint>();
+        private int currentPosition = -1;
 
         public void Add(uint did)
         {
             // don't add consecutive duplicates
-            if (DID.Count > 0 && DID[DID.Count - 1] == did)
+            if (currentPosition >= 0 && currentPosition < DID.Count && DID[currentPosition] == did)
                 return;
-            
-            DID.Add(did);
 
+            // If we're in the middle of history (user went back), remove forward history
+            if (currentPosition < DID.Count - 1)
+            {
+                DID.RemoveRange(currentPosition + 1, DID.Count - currentPosition - 1);
+            }
+
+            DID.Add(did);
+            currentPosition = DID.Count - 1;
+
+            // Trim old history if exceeds max size
             if (DID.Count > MaxSize)
+            {
                 DID.RemoveAt(0);
+                currentPosition--;
+            }
         }
 
         public void Clear()
         {
             DID.Clear();
+            currentPosition = -1;
         }
 
+        /// <summary>
+        /// Go back in history. Returns the previous DID, or null if at the start.
+        /// </summary>
+        public uint? Back()
+        {
+            if (!CanGoBack()) return null;
+
+            currentPosition--;
+            return DID[currentPosition];
+        }
+
+        /// <summary>
+        /// Go forward in history. Returns the next DID, or null if at the end.
+        /// </summary>
+        public uint? Forward()
+        {
+            if (!CanGoForward()) return null;
+
+            currentPosition++;
+            return DID[currentPosition];
+        }
+
+        /// <summary>
+        /// Check if we can go back in history
+        /// </summary>
+        public bool CanGoBack()
+        {
+            return currentPosition > 0;
+        }
+
+        /// <summary>
+        /// Check if we can go forward in history
+        /// </summary>
+        public bool CanGoForward()
+        {
+            return currentPosition >= 0 && currentPosition < DID.Count - 1;
+        }
+
+        /// <summary>
+        /// Get list of DIDs available to go back to (most recent first)
+        /// </summary>
+        public List<uint> GetBackList()
+        {
+            var backList = new List<uint>();
+            for (int i = currentPosition - 1; i >= 0; i--)
+            {
+                backList.Add(DID[i]);
+            }
+            return backList;
+        }
+
+        /// <summary>
+        /// Get list of DIDs available to go forward to (nearest first)
+        /// </summary>
+        public List<uint> GetForwardList()
+        {
+            var forwardList = new List<uint>();
+            for (int i = currentPosition + 1; i < DID.Count; i++)
+            {
+                forwardList.Add(DID[i]);
+            }
+            return forwardList;
+        }
+
+        /// <summary>
+        /// Navigate to a specific DID in history by index offset from current position
+        /// </summary>
+        /// <param name="offset">Negative for back, positive for forward</param>
+        public uint? NavigateByOffset(int offset)
+        {
+            int targetPosition = currentPosition + offset;
+            if (targetPosition < 0 || targetPosition >= DID.Count)
+                return null;
+
+            currentPosition = targetPosition;
+            return DID[currentPosition];
+        }
+
+        /// <summary>
+        /// Legacy Pop() method for backwards compatibility with Backspace hotkey
+        /// </summary>
         public uint? Pop()
         {
-            if (DID.Count <= 1) return null;
-
-            DID.RemoveAt(DID.Count - 1);
-
-            return DID[DID.Count - 1];
+            return Back();
         }
     }
 }

--- a/ACViewer/View/FileExplorer.xaml.cs
+++ b/ACViewer/View/FileExplorer.xaml.cs
@@ -43,6 +43,7 @@ namespace ACViewer.View
         public bool TeleportMode { get; set; }
 
         public History History { get; set; }
+        public bool SuppressHistory { get; set; }
 
         public List<string> FileIDs
         {
@@ -188,12 +189,15 @@ namespace ACViewer.View
             if (fileID == 0) return;
 
             Selected_FileID = fileID;
-            History.Add(fileID);
+            if (!SuppressHistory)
+                History.Add(fileID);
 
             if (PortalMode)
                 ReadPortalFile(fileID);
             else
                 ReadCellFile(fileID);
+        // Update navigation buttons after any navigation
+        MainWindow?.menuMain?.UpdateNavigationButtons();
         }
 
         public void ReadCellFile(uint fileID)

--- a/ACViewer/View/MainMenu.xaml
+++ b/ACViewer/View/MainMenu.xaml
@@ -72,6 +72,16 @@
                     </MenuItem.Icon>                    
                 </MenuItem>
             </MenuItem>
+            <MenuItem x:Name="menuBack" Header="Back" Click="Back_Click" InputGestureText="Backspace" IsEnabled="False">
+                <MenuItem.ContextMenu>
+                    <ContextMenu x:Name="menuBackContext" Opened="BackContext_Opened" />
+                </MenuItem.ContextMenu>
+            </MenuItem>
+            <MenuItem x:Name="menuForward" Header="Forward" Click="Forward_Click" InputGestureText="Alt+Right" IsEnabled="False">
+                <MenuItem.ContextMenu>
+                    <ContextMenu x:Name="menuForwardContext" Opened="ForwardContext_Opened" />
+                </MenuItem.ContextMenu>
+            </MenuItem>
         </Menu>            
     </Grid>
 </UserControl>

--- a/ACViewer/View/MainMenu.xaml.cs
+++ b/ACViewer/View/MainMenu.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
@@ -400,6 +401,153 @@ namespace ACViewer.View
         {
             var armorWindow = new ArmorList();
             armorWindow.ShowDialog();
+        }
+
+        private void Back_Click(object sender, RoutedEventArgs e)
+        {
+            if (FileExplorer.Instance?.History == null) return;
+
+            var prevDID = FileExplorer.Instance.History.Back();
+
+            if (prevDID == null) return;
+
+            // Navigate without adding to history (we're already in history)
+            FileExplorer.Instance.SuppressHistory = true;
+            Finder.Navigate(prevDID.Value.ToString("X8"));
+            FileExplorer.Instance.SuppressHistory = false;
+
+            UpdateNavigationButtons();
+        }
+
+        private void Forward_Click(object sender, RoutedEventArgs e)
+        {
+            if (FileExplorer.Instance?.History == null) return;
+
+            var nextDID = FileExplorer.Instance.History.Forward();
+
+            if (nextDID == null) return;
+
+            // Navigate without adding to history (we're already in history)
+            FileExplorer.Instance.SuppressHistory = true;
+            Finder.Navigate(nextDID.Value.ToString("X8"));
+            FileExplorer.Instance.SuppressHistory = false;
+
+            UpdateNavigationButtons();
+        }
+
+        public void UpdateNavigationButtons()
+        {
+            var history = FileExplorer.Instance?.History;
+            if (history == null || menuBack == null || menuForward == null) return;
+
+            menuBack.IsEnabled = history.CanGoBack();
+            menuForward.IsEnabled = history.CanGoForward();
+        }
+
+        private void BackContext_Opened(object sender, RoutedEventArgs e)
+        {
+            var contextMenu = sender as ContextMenu;
+            if (contextMenu == null) return;
+
+            contextMenu.Items.Clear();
+
+            var history = FileExplorer.Instance?.History;
+            if (history == null) return;
+
+            var backList = history.GetBackList();
+            for (int i = 0; i < backList.Count; i++)
+            {
+                var did = backList[i];
+                var menuItem = new MenuItem
+                {
+                    Header = GetFileTypeLabel(did),
+                    Tag = -(i + 1) // Negative offset for going back
+                };
+                menuItem.Click += HistoryItem_Click;
+                contextMenu.Items.Add(menuItem);
+            }
+        }
+
+        private void ForwardContext_Opened(object sender, RoutedEventArgs e)
+        {
+            var contextMenu = sender as ContextMenu;
+            if (contextMenu == null) return;
+
+            contextMenu.Items.Clear();
+
+            var history = FileExplorer.Instance?.History;
+            if (history == null) return;
+
+            var forwardList = history.GetForwardList();
+            for (int i = 0; i < forwardList.Count; i++)
+            {
+                var did = forwardList[i];
+                var menuItem = new MenuItem
+                {
+                    Header = GetFileTypeLabel(did),
+                    Tag = i + 1 // Positive offset for going forward
+                };
+                menuItem.Click += HistoryItem_Click;
+                contextMenu.Items.Add(menuItem);
+            }
+        }
+
+        private void HistoryItem_Click(object sender, RoutedEventArgs e)
+        {
+            var menuItem = sender as MenuItem;
+            if (menuItem?.Tag == null) return;
+
+            var offset = (int)menuItem.Tag;
+            var history = FileExplorer.Instance?.History;
+            if (history == null) return;
+
+            var targetDID = history.NavigateByOffset(offset);
+            if (targetDID == null) return;
+
+            // Navigate without adding to history
+            FileExplorer.Instance.SuppressHistory = true;
+            Finder.Navigate(targetDID.Value.ToString("X8"));
+            FileExplorer.Instance.SuppressHistory = false;
+
+            UpdateNavigationButtons();
+        }
+
+        private string GetFileTypeLabel(uint did)
+        {
+            var fileTypeID = did >> 24;
+            var fileTypeName = "Unknown";
+
+            // Check FileExplorer's FileTypes list
+            if (FileExplorer.FileTypes != null)
+            {
+                // First try exact match (for special IDs like CharGen)
+                var exactMatch = FileExplorer.FileTypes.FirstOrDefault(ft => ft.ID == did);
+                if (exactMatch != null)
+                {
+                    fileTypeName = exactMatch.Name;
+                }
+                else
+                {
+                    // Then try by high byte
+                    var typeMatch = FileExplorer.FileTypes.FirstOrDefault(ft => ft.ID == fileTypeID);
+                    if (typeMatch != null)
+                    {
+                        fileTypeName = typeMatch.Name;
+                    }
+                    else
+                    {
+                        // Special cases for Cell and Landblock
+                        if ((did & 0xFFFF) == 0xFFFF)
+                            fileTypeName = "Landblock";
+                        else if ((did & 0xFFFF) == 0xFFFE)
+                            fileTypeName = "LandblockInfo";
+                        else if (fileTypeID == 0)
+                            fileTypeName = "EnvCell";
+                    }
+                }
+            }
+
+            return $"{fileTypeName} - 0x{did:X8}";
         }
     }
 }

--- a/AppVeyor/AppVeyorInstall.ps1
+++ b/AppVeyor/AppVeyorInstall.ps1
@@ -1,2 +1,2 @@
 Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
-& $env:temp\dotnet-install.ps1 -Architecture x64 -Version '3.1' -InstallDir "$env:ProgramFiles\dotnet"
+& $env:temp\dotnet-install.ps1 -Architecture x64 -Version '3.1.32' -InstallDir "$env:ProgramFiles\dotnet"

--- a/AppVeyor/AppVeyorInstall.ps1
+++ b/AppVeyor/AppVeyorInstall.ps1
@@ -1,0 +1,2 @@
+Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
+& $env:temp\dotnet-install.ps1 -Architecture x64 -Version '3.1' -InstallDir "$env:ProgramFiles\dotnet"

--- a/AppVeyor/AppVeyorInstall.ps1
+++ b/AppVeyor/AppVeyorInstall.ps1
@@ -1,2 +1,2 @@
 Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
-& $env:temp\dotnet-install.ps1 -Architecture x64 -Version '3.1.32' -InstallDir "$env:ProgramFiles\dotnet"
+& $env:temp\dotnet-install.ps1 -Architecture x64 -Version '3.1.426' -InstallDir "$env:ProgramFiles\dotnet"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ configuration:
 - Debug
 platform: x64
 install:
-  - ps: Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1" & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '3.1' -InstallDir "$env:ProgramFiles\dotnet"
+  - ps: AppVeyor\AppVeyorInstall.ps1
 before_build:
 - cmd: >-
     git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
   only:
   - master
 skip_tags: true
-image: Visual Studio 2022
+image: Previous Visual Studio 2022
 configuration:
 - Release
 - Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,13 @@ branches:
   only:
   - master
 skip_tags: true
-image: Previous Visual Studio 2022
+image: Visual Studio 2022
 configuration:
 - Release
 - Debug
 platform: x64
+install:
+  - ps: Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1" & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '3.1' -InstallDir "$env:ProgramFiles\dotnet"
 before_build:
 - cmd: >-
     git submodule update --init --recursive


### PR DESCRIPTION
## Summary
Implemented bidirectional navigation system allowing users to browse through their file viewing history similar to web browser navigation.

## Features
- Back button (Backspace) to navigate to previously viewed files
- Forward button (Alt+Right) to navigate forward in history
- Right-click context menus on both buttons showing full navigation history
- File type labels in context menus (e.g., "Surface - 0x080001AE")
- Jump directly to any point in history from context menu
- History limited to 50 items with automatic trimming
- Buttons auto-enable/disable based on available history

## Changes
- Rewrote History.cs with bidirectional navigation support
- Added SuppressHistory flag to FileExplorer to prevent duplicate entries
- Added Back/Forward menu items to main menu bar
- Added context menu handlers with file type resolution