### PR TITLE
Add particle effects and surface usage information to file displays

### DIFF
--- a/ACViewer/FileTypes/GfxObj.cs
+++ b/ACViewer/FileTypes/GfxObj.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 using ACE.Entity.Enum;
 
@@ -21,14 +23,25 @@ namespace ACViewer.FileTypes
 
             var surfaces = new TreeNode("Surfaces");
 
-            foreach (var surface in _gfxObj.Surfaces)
-                surfaces.Items.Add(new TreeNode($"{surface:X8}", clickable: true));
+            for (var i = 0; i < _gfxObj.Surfaces.Count; i++)
+            {
+                var surface = _gfxObj.Surfaces[i];
+                surfaces.Items.Add(new TreeNode($"Surface {i}: {surface:X8}", clickable: true));
+            }
+
+            // Build surface usage summary
+            var surfaceUsageSummary = BuildSurfaceUsageSummary();
 
             var vertexArray = new TreeNode("VertexArray");
             foreach (var item in new VertexArray(_gfxObj.VertexArray).BuildTree())
                 vertexArray.Items.Add(item);
 
-            treeView.Items.AddRange(new List<TreeNode>() { surfaces, vertexArray });
+            var nodesToAdd = new List<TreeNode>() { surfaces };
+            if (surfaceUsageSummary != null)
+                nodesToAdd.Add(surfaceUsageSummary);
+            nodesToAdd.Add(vertexArray);
+
+            treeView.Items.AddRange(nodesToAdd);
 
             if (_gfxObj.Flags.HasFlag(GfxObjFlags.HasPhysics))
             {
@@ -74,6 +87,61 @@ namespace ACViewer.FileTypes
             }
 
             return treeView;
+        }
+
+        private TreeNode BuildSurfaceUsageSummary()
+        {
+            if (_gfxObj.Polygons == null || _gfxObj.Polygons.Count == 0)
+                return null;
+
+            // Map surface index -> list of polygon indices that use it
+            var surfaceToPolygons = new Dictionary<int, List<int>>();
+
+            foreach (var kvp in _gfxObj.Polygons)
+            {
+                var polygonIndex = kvp.Key;
+                var polygon = kvp.Value;
+
+                // Track PosSurface
+                if (polygon.PosSurface >= 0 && polygon.PosSurface < _gfxObj.Surfaces.Count)
+                {
+                    if (!surfaceToPolygons.ContainsKey((int)polygon.PosSurface))
+                        surfaceToPolygons[(int)polygon.PosSurface] = new List<int>();
+                    surfaceToPolygons[(int)polygon.PosSurface].Add(polygonIndex);
+                }
+
+                // Track NegSurface if different from PosSurface
+                if (polygon.NegSurface >= 0 && polygon.NegSurface < _gfxObj.Surfaces.Count && polygon.NegSurface != polygon.PosSurface)
+                {
+                    if (!surfaceToPolygons.ContainsKey((int)polygon.NegSurface))
+                        surfaceToPolygons[(int)polygon.NegSurface] = new List<int>();
+                    surfaceToPolygons[(int)polygon.NegSurface].Add(polygonIndex);
+                }
+            }
+
+            if (surfaceToPolygons.Count == 0)
+                return null;
+
+            var summaryNode = new TreeNode("Surface Usage Summary:");
+
+            foreach (var surfaceIdx in surfaceToPolygons.Keys.OrderBy(k => k))
+            {
+                var polygonIndices = surfaceToPolygons[surfaceIdx];
+                var surfaceId = _gfxObj.Surfaces[surfaceIdx];
+
+                var usageNode = new TreeNode($"Surface {surfaceIdx} ({surfaceId:X8}): Used by {polygonIndices.Count} polygon(s)");
+
+                // Show first few polygon indices
+                var polygonList = string.Join(", ", polygonIndices.Take(10));
+                if (polygonIndices.Count > 10)
+                    polygonList += $", ... ({polygonIndices.Count - 10} more)";
+
+                usageNode.Items.Add(new TreeNode($"Polygons: {polygonList}"));
+
+                summaryNode.Items.Add(usageNode);
+            }
+
+            return summaryNode;
         }
     }
 }

--- a/ACViewer/FileTypes/Setup.cs
+++ b/ACViewer/FileTypes/Setup.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
+using ACE.DatLoader;
 using ACE.Entity.Enum;
 
 using ACViewer.Entity;
@@ -139,9 +141,85 @@ namespace ACViewer.FileTypes
                 treeView.Items.Add(new TreeNode($"Default sound table: {_setup.DefaultSoundTable:X8}", clickable: true));
 
             if (_setup.DefaultScriptTable != 0)
+            {
                 treeView.Items.Add(new TreeNode($"Default script table: {_setup.DefaultScriptTable:X8}", clickable: true));
 
+                // Add particle effects summary
+                var particleEffectsSummary = BuildParticleEffectsSummary();
+                if (particleEffectsSummary != null && particleEffectsSummary.Items.Count > 0)
+                    treeView.Items.Add(particleEffectsSummary);
+            }
+
             return treeView;
+        }
+
+        private TreeNode BuildParticleEffectsSummary()
+        {
+            if (_setup.DefaultScriptTable == 0)
+                return null;
+
+            try
+            {
+                var scriptTable = DatManager.PortalDat.ReadFromDat<ACE.DatLoader.FileTypes.PhysicsScriptTable>(_setup.DefaultScriptTable);
+                if (scriptTable == null || scriptTable.ScriptTable == null || scriptTable.ScriptTable.Count == 0)
+                    return null;
+
+                var summaryNode = new TreeNode("Particle Effects Summary:");
+
+                foreach (var kvp in scriptTable.ScriptTable.OrderBy(x => x.Key))
+                {
+                    var playScript = (PlayScript)kvp.Key;
+                    var scriptTableData = kvp.Value;
+
+                    // For each script mod entry, get the PhysicsScript and look for CreateParticleHooks
+                    foreach (var scriptMod in scriptTableData.Scripts)
+                    {
+                        try
+                        {
+                            var physicsScript = DatManager.PortalDat.ReadFromDat<ACE.DatLoader.FileTypes.PhysicsScript>(scriptMod.ScriptId);
+                            if (physicsScript == null || physicsScript.ScriptData == null || physicsScript.ScriptData.Count == 0)
+                                continue;
+
+                            var particleHooks = new List<ACE.DatLoader.Entity.AnimationHooks.CreateParticleHook>();
+
+                            foreach (var scriptData in physicsScript.ScriptData)
+                            {
+                                if (scriptData.Hook.HookType == AnimationHookType.CreateParticle)
+                                {
+                                    var hook = scriptData.Hook as ACE.DatLoader.Entity.AnimationHooks.CreateParticleHook;
+                                    if (hook != null)
+                                        particleHooks.Add(hook);
+                                }
+                            }
+
+                            if (particleHooks.Count > 0)
+                            {
+                                var playScriptNode = new TreeNode($"{playScript}" + (scriptMod.Mod != 0 ? $" (Mod: {scriptMod.Mod})" : ""));
+
+                                foreach (var hook in particleHooks)
+                                {
+                                    var hookNode = new TreeNode($"CreateParticle - EmitterInfo: {hook.EmitterInfoId:X8}, Part: {(int)hook.PartIndex}, EmitterId: {hook.EmitterId}", clickable: true);
+                                    playScriptNode.Items.Add(hookNode);
+                                }
+
+                                summaryNode.Items.Add(playScriptNode);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            // Skip entries that can't be loaded
+                            Console.WriteLine($"Error loading PhysicsScript {scriptMod.ScriptId:X8}: {ex.Message}");
+                        }
+                    }
+                }
+
+                return summaryNode.Items.Count > 0 ? summaryNode : null;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error building particle effects summary: {ex.Message}");
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Enhanced the Setup and GfxObj file type displays to show more detailed information about particle effects and surface usage patterns.

## Features
- **Particle Effects Summary** in Setup files showing CreateParticleHook details
  - Display organized by PlayScript type
  - Shows EmitterInfo ID, Part index, and EmitterId for each particle hook
  - Handles missing or invalid entries gracefully
  
- **Surface Usage Summary** in GfxObj files showing polygon-to-surface mapping
  - Enhanced surface display with indexed labels (e.g., "Surface 0: 0x080001AE")
  - Shows which polygons use each surface
  - Displays polygon counts and lists polygon indices (first 10, then "... X more")
  - Tracks both PosSurface and NegSurface usage

## Changes
- **Setup.cs**: Added `BuildParticleEffectsSummary()` method that reads PhysicsScriptTable data
- **GfxObj.cs**: Added `BuildSurfaceUsageSummary()` method and enhanced surface display formatting