### PR TITLE
Add name/text search linking ace_world data to dat assets

### DIFF
--- a/ACViewer/Data/WeenieSearchIndex.cs
+++ b/ACViewer/Data/WeenieSearchIndex.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+
+using ACE.Database.Models.World;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+
+namespace ACViewer.Data
+{
+    /// <summary>
+    /// A weenie that has been resolved to a renderable dat asset. Searchable text is split
+    /// into tiers so a match on the actual name/class ranks above a match that's only an
+    /// incidental mention inside another weenie's flavor text (e.g. a Drudge's LongDesc
+    /// name-dropping Mosswarts shouldn't outrank an actual Mosswart).
+    /// </summary>
+    public class WeenieSearchEntry
+    {
+        public uint Wcid;
+        public string ClassName;
+        public string Name;
+        public string WeenieType;
+        public uint SetupId;
+
+        // grouping key -- many WCIDs commonly share one Setup dat asset (e.g. same model at
+        // different Scale/PaletteBase for a Baby/Chief/Elder tier), so results are grouped by this
+        public string SetupIdHex => SetupId.ToString("X8");
+
+        // lowercased search fields, ordered by how much they're trusted:
+        // tier 0-1: the player-facing display name
+        public string NameLower;
+        // tier 2: structured category data (WeenieType, CreatureType, HeritageGroup, etc.) --
+        // authoritative, unlike ClassName/DescText below
+        public string CategoryText;
+        // tier 3: the dev/internal class name -- can reference unrelated content it was reused/placed
+        // in (e.g. a Drudge named "...mosswartexodus" for the dungeon it spawns in), so it's trusted
+        // less than the actual Name or structured CreatureType/HeritageGroup data
+        public string ClassNameLower;
+        // tier 4: narrative/free text (Title, Use, ShortDesc, LongDesc, ...)
+        public string DescText;
+
+        public override string ToString() => $"{Wcid} - {Name} ({WeenieType})";
+    }
+
+    /// <summary>
+    /// A one-time, in-memory index of ace_world weenie names/descriptions/categories,
+    /// built the same way FileExplorer's other lookup tables (DIDTables, LootArmorList) are --
+    /// loaded once, then searched in memory, so the UI never blocks on a live query per keystroke.
+    /// </summary>
+    public static class WeenieSearchIndex
+    {
+        private const string CacheFilename = "WeenieSearchCache.json";
+
+        private class CacheFile
+        {
+            public DateTime BuiltAt { get; set; }
+            public DateTime LastModifiedMarker { get; set; }
+            public string DatabaseHost { get; set; }
+            public string DatabaseName { get; set; }
+            public List<WeenieSearchEntry> Entries { get; set; }
+        }
+
+        public static List<WeenieSearchEntry> Entries { get; private set; }
+
+        // distinct WeenieType names actually present in the indexed data, for the type-filter
+        // dropdown -- built from the real data rather than the full WeenieType enum, since not
+        // every enum member shows up among renderable weenies
+        public static List<string> AvailableWeenieTypes { get; private set; }
+
+        public static bool IsLoaded => Entries != null;
+
+        // human-readable summary of the last Load() call (cache hit or DB rebuild), for the status log
+        public static string LastLoadSummary { get; private set; }
+
+        /// <summary>
+        /// forceRefresh bypasses the cache and always rebuilds from the database, saving a fresh cache
+        /// </summary>
+        public static void Load(bool forceRefresh = false)
+        {
+            var dbHost = ACViewer.Config.ConfigManager.Config.Database.Host;
+            var dbName = ACViewer.Config.ConfigManager.Config.Database.DatabaseName;
+
+            using (var context = new WorldDbContext())
+            {
+                context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+
+                // the weenie table's last_Modified column auto-updates on any row change, so its
+                // max value is a cheap fingerprint for "has anything changed since the cache was built"
+                var marker = context.Weenie.Max(w => w.LastModified);
+
+                if (!forceRefresh && TryLoadFromCache(marker, dbHost, dbName))
+                    return;
+
+                var weenies = context.Weenie
+                    .Include(r => r.WeeniePropertiesString)
+                    .Include(r => r.WeeniePropertiesInt)
+                    .Include(r => r.WeeniePropertiesDID)
+                    .ToList();
+
+                var entries = new List<WeenieSearchEntry>();
+
+                foreach (var weenie in weenies)
+                {
+                    var setupId = weenie.WeeniePropertiesDID.FirstOrDefault(d => d.Type == (ushort)PropertyDataId.Setup)?.Value ?? 0;
+
+                    // nothing to render for this weenie in the dat viewer -- skip it
+                    if (setupId == 0)
+                        continue;
+
+                    var name = weenie.WeeniePropertiesString.FirstOrDefault(s => s.Type == (ushort)PropertyString.Name)?.Value ?? "";
+                    var weenieType = (WeenieType)weenie.Type;
+
+                    var categoryTerms = new List<string> { System.Enum.GetName(typeof(WeenieType), weenieType) };
+                    var descTerms = new List<string>();
+
+                    foreach (var prop in weenie.WeeniePropertiesString)
+                    {
+                        if (prop.Type == (ushort)PropertyString.Name)
+                            continue;
+
+                        descTerms.Add(prop.Value);
+                    }
+
+                    foreach (var prop in weenie.WeeniePropertiesInt)
+                    {
+                        var enumName = ((PropertyInt)prop.Type).GetValueEnumName(prop.Value);
+                        if (enumName != null)
+                            categoryTerms.Add(enumName);
+                    }
+
+                    entries.Add(new WeenieSearchEntry
+                    {
+                        Wcid = weenie.ClassId,
+                        ClassName = weenie.ClassName,
+                        Name = name,
+                        WeenieType = System.Enum.GetName(typeof(WeenieType), weenieType),
+                        SetupId = setupId,
+                        NameLower = name.ToLowerInvariant(),
+                        CategoryText = string.Join(" ", categoryTerms.Where(t => !string.IsNullOrEmpty(t))).ToLowerInvariant(),
+                        ClassNameLower = (weenie.ClassName ?? "").ToLowerInvariant(),
+                        DescText = string.Join(" ", descTerms.Where(t => !string.IsNullOrEmpty(t))).ToLowerInvariant()
+                    });
+                }
+
+                Entries = entries;
+                AvailableWeenieTypes = entries.Select(e => e.WeenieType).Distinct()
+                    .OrderBy(t => t, StringComparer.OrdinalIgnoreCase).ToList();
+
+                var builtAt = DateTime.Now;
+                SaveCache(marker, dbHost, dbName, builtAt, entries);
+
+                LastLoadSummary = $"Weenie search index rebuilt from database {dbHost}/{dbName} at {builtAt:yyyy-MM-dd HH:mm:ss} " +
+                    $"(db last modified {marker:yyyy-MM-dd HH:mm:ss}) -- {entries.Count:N0} weenies, cached for next run";
+            }
+        }
+
+        /// <returns>true if the cache was present, valid for this marker/database, and successfully loaded</returns>
+        private static bool TryLoadFromCache(DateTime marker, string dbHost, string dbName)
+        {
+            try
+            {
+                if (!File.Exists(CacheFilename))
+                    return false;
+
+                var cache = JsonConvert.DeserializeObject<CacheFile>(File.ReadAllText(CacheFilename));
+
+                if (cache?.Entries == null)
+                    return false;
+
+                if (cache.LastModifiedMarker != marker || cache.DatabaseHost != dbHost || cache.DatabaseName != dbName)
+                    return false;
+
+                Entries = cache.Entries;
+                AvailableWeenieTypes = Entries.Select(e => e.WeenieType).Distinct()
+                    .OrderBy(t => t, StringComparer.OrdinalIgnoreCase).ToList();
+
+                LastLoadSummary = $"Weenie search index loaded from cache -- last refreshed {cache.BuiltAt:yyyy-MM-dd HH:mm:ss} " +
+                    $"from {cache.DatabaseHost}/{cache.DatabaseName} (db last modified {cache.LastModifiedMarker:yyyy-MM-dd HH:mm:ss}) -- {Entries.Count:N0} weenies";
+
+                return true;
+            }
+            catch
+            {
+                // corrupt/unreadable cache file -- fall back to rebuilding from the database
+                return false;
+            }
+        }
+
+        private static void SaveCache(DateTime marker, string dbHost, string dbName, DateTime builtAt, List<WeenieSearchEntry> entries)
+        {
+            try
+            {
+                var cache = new CacheFile
+                {
+                    BuiltAt = builtAt,
+                    LastModifiedMarker = marker,
+                    DatabaseHost = dbHost,
+                    DatabaseName = dbName,
+                    Entries = entries
+                };
+
+                var json = JsonConvert.SerializeObject(cache, new JsonSerializerSettings { Formatting = Formatting.Indented });
+                File.WriteAllText(CacheFilename, json);
+            }
+            catch
+            {
+                // caching is a nice-to-have -- if writing it fails (e.g. read-only directory), just skip it
+            }
+        }
+
+        /// <summary>
+        /// Lower is a better match: 0/1 = the display Name, 2 = structured category data
+        /// (WeenieType, CreatureType, HeritageGroup, ...), 3 = only the internal dev class name,
+        /// 4 = only found in narrative text. Category (2) outranks ClassName (3) because the dev
+        /// class name can reference unrelated content (see ClassNameLower doc above) while
+        /// CreatureType/HeritageGroup are authoritative about what the weenie actually is.
+        /// Returns null if the term isn't found anywhere in the entry.
+        /// </summary>
+        private static int? MatchTier(WeenieSearchEntry e, string term)
+        {
+            if (e.Name.Equals(term, StringComparison.OrdinalIgnoreCase)) return 0;
+            if (e.NameLower.Contains(term)) return 1;
+            if (e.CategoryText.Contains(term)) return 2;
+            if (e.ClassNameLower.Contains(term)) return 3;
+            if (e.DescText.Contains(term)) return 4;
+            return null;
+        }
+
+        /// <summary>
+        /// weenieTypeFilters: null/empty means no type restriction, otherwise an entry's WeenieType
+        /// must be one of the given values (multi-select). query: null/empty is allowed as long as
+        /// at least one type filter is given -- that's a "browse by type" with no text ranking needed.
+        /// </summary>
+        public static List<WeenieSearchEntry> Search(string query, ICollection<string> weenieTypeFilters = null)
+        {
+            if (Entries == null)
+                return new List<WeenieSearchEntry>();
+
+            var hasQuery = !string.IsNullOrWhiteSpace(query);
+            var hasTypeFilter = weenieTypeFilters != null && weenieTypeFilters.Count > 0;
+
+            if (!hasQuery && !hasTypeFilter)
+                return new List<WeenieSearchEntry>();
+
+            IEnumerable<WeenieSearchEntry> source = Entries;
+            if (hasTypeFilter)
+            {
+                var typeSet = new HashSet<string>(weenieTypeFilters);
+                source = source.Where(e => typeSet.Contains(e.WeenieType));
+            }
+
+            if (!hasQuery)
+            {
+                // pure type browse -- no text to rank against, just list alphabetically
+                return source.OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase).ThenBy(e => e.Wcid).ToList();
+            }
+
+            var term = query.Trim().ToLowerInvariant();
+
+            return source
+                .Select(e => (Entry: e, Tier: MatchTier(e, term)))
+                .Where(m => m.Tier != null)
+                .OrderBy(m => m.Tier)
+                .ThenBy(m => m.Entry.Name.Length)
+                .ThenBy(m => m.Entry.Wcid)
+                .Select(m => m.Entry)
+                .ToList();
+        }
+    }
+}

--- a/ACViewer/Server.cs
+++ b/ACViewer/Server.cs
@@ -343,23 +343,91 @@ namespace ACViewer
 
         public static void TryPrimeDatabase()
         {
-            SetDatabaseConfig();
+            try
+            {
+                SetDatabaseConfig();
+            }
+            catch (Exception ex)
+            {
+                // SetDatabaseConfig runs on the caller's thread (here, during app startup) --
+                // an unhandled exception this early can take the whole app down silently,
+                // so this must never be allowed to escape uncaught
+                MainWindow.Instance.Status.WriteLine($"ace_world database configuration failed: {ex.Message}");
+                View.FileExplorer.Instance.OnSearchIndexLoaded(false);
+                return;
+            }
 
             var worker = new BackgroundWorker();
 
             worker.DoWork += (sender, doWorkEventArgs) =>
             {
-                try
+                using (var ctx = new WorldDbContext())
                 {
-                    using (var ctx = new WorldDbContext())
-                    {
-                        var weenie = ctx.Weenie.FirstOrDefault();
-                    }
+                    var weenie = ctx.Weenie.FirstOrDefault();
                 }
-                catch (Exception)
-                {
-                }
+
+                ACViewer.Data.WeenieSearchIndex.Load();
             };
+            worker.RunWorkerCompleted += (sender, args) =>
+            {
+                if (args.Error != null)
+                {
+                    MainWindow.Instance.Status.WriteLine($"ace_world database connection failed: {args.Error.Message}");
+                    View.FileExplorer.Instance.OnSearchIndexLoaded(false);
+                    return;
+                }
+
+                var loaded = ACViewer.Data.WeenieSearchIndex.IsLoaded;
+
+                MainWindow.Instance.Status.WriteLine(loaded
+                    ? ACViewer.Data.WeenieSearchIndex.LastLoadSummary
+                    : "Weenie search index failed to load -- check the ace_world database connection");
+
+                View.FileExplorer.Instance.OnSearchIndexLoaded(loaded);
+            };
+
+            MainWindow.Instance.Status.WriteLine("Loading weenie search index...");
+            worker.RunWorkerAsync();
+        }
+
+        /// <summary>
+        /// Forces a rebuild of the weenie search index from the database, bypassing the cache file.
+        /// Manual escape hatch for cases the cache's last_Modified check can't catch, like deletions.
+        /// </summary>
+        public static void RefreshWeenieSearchIndex()
+        {
+            try
+            {
+                SetDatabaseConfig();
+            }
+            catch (Exception ex)
+            {
+                MainWindow.Instance.Status.WriteLine($"ace_world database configuration failed: {ex.Message}");
+                return;
+            }
+
+            var worker = new BackgroundWorker();
+
+            worker.DoWork += (sender, doWorkEventArgs) =>
+            {
+                ACViewer.Data.WeenieSearchIndex.Load(forceRefresh: true);
+            };
+            worker.RunWorkerCompleted += (sender, args) =>
+            {
+                // args.Error (not IsLoaded) is the right success check here -- unlike TryPrimeDatabase's
+                // first-ever load, this can run after a prior successful load, so IsLoaded would still
+                // read true from that earlier state even if this refresh attempt itself failed
+                if (args.Error != null)
+                {
+                    MainWindow.Instance.Status.WriteLine($"Weenie search index refresh failed: {args.Error.Message}");
+                    return;
+                }
+
+                MainWindow.Instance.Status.WriteLine(ACViewer.Data.WeenieSearchIndex.LastLoadSummary);
+                View.FileExplorer.Instance.OnSearchIndexLoaded(true);
+            };
+
+            MainWindow.Instance.Status.WriteLine("Refreshing weenie search index from database...");
             worker.RunWorkerAsync();
         }
 

--- a/ACViewer/View/App.xaml.cs
+++ b/ACViewer/View/App.xaml.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Threading;
 
 namespace ACViewer.View
 {
@@ -13,5 +15,46 @@ namespace ACViewer.View
     /// </summary>
     public partial class App : Application
     {
+        public App()
+        {
+            // last-resort safety net -- without this, any unhandled exception anywhere in the
+            // app (on any thread) can silently take down the whole process with no indication why
+            DispatcherUnhandledException += OnDispatcherUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+        }
+
+        private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            LogFatal(e.Exception);
+
+            // this one CAN be kept alive -- it's on the UI thread, so marking it handled
+            // prevents the crash instead of just logging it on the way down.
+            // Fully qualified: "MainWindow" here would otherwise resolve to Application.MainWindow
+            if (ACViewer.View.MainWindow.Instance != null)
+                ACViewer.View.MainWindow.Instance.Status.WriteLine($"Unhandled error: {e.Exception.Message} (see error.log)");
+
+            e.Handled = true;
+        }
+
+        private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            // exceptions on non-UI threads can't be stopped from here (the process will still
+            // terminate) -- this exists purely so the failure is logged instead of the process
+            // just vanishing with no explanation. Note: don't touch WPF UI elements here --
+            // this may not be firing on the UI thread
+            LogFatal(e.ExceptionObject as Exception);
+        }
+
+        private static void LogFatal(Exception ex)
+        {
+            try
+            {
+                File.AppendAllText("error.log", $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} {ex}\n\n");
+            }
+            catch
+            {
+                // if we can't even write the log, there's nothing more we can safely do here
+            }
+        }
     }
 }

--- a/ACViewer/View/FileExplorer.xaml
+++ b/ACViewer/View/FileExplorer.xaml
@@ -12,17 +12,87 @@
             <RowDefinition Height="22.5"/>
             <RowDefinition Height=".5*"/>
             <RowDefinition Height=".5*"/>
+            <RowDefinition Height="25"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
             <ColumnDefinition MaxWidth="178"/>
         </Grid.ColumnDefinitions>
-        <Label Content="File Type" Grid.ColumnSpan="2"/>
+        <Label Content="File Type" Grid.Row="0" Grid.ColumnSpan="2"/>
         <ComboBox Name="FileType" Width="174" ItemsSource="{Binding FileTypes}" Grid.Row="1"  Grid.ColumnSpan="2" Margin="7.5,0,0,0" SelectionChanged="FileType_SelectionChanged" HorizontalAlignment="Left"/>
         <ListBox Name="Files" Margin="7.5,7.5,0,0" ItemsSource="{Binding FileIDs}" Grid.Row="2" SelectionChanged="Files_SelectionChanged"/>
+        <ListBox Name="SearchResultsList" Margin="7.5,7.5,0,0" Grid.Row="2" SelectionChanged="SearchResults_SelectionChanged" Visibility="Collapsed"
+                 VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling" VirtualizingPanel.ScrollUnit="Item">
+            <ListBox.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.ContainerStyle>
+                        <Style TargetType="{x:Type GroupItem}">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type GroupItem}">
+                                        <Expander IsExpanded="False" Background="#22000000" Margin="0,0,0,1">
+                                            <Expander.Header>
+                                                <StackPanel Orientation="Horizontal" Background="Transparent" Cursor="Hand" ToolTip="Click to jump to this asset" MouseLeftButtonDown="GroupHeader_Click">
+                                                    <TextBlock Text="{Binding Name}" FontWeight="Bold" Padding="2,2,0,2"/>
+                                                    <TextBlock Text="{Binding ItemCount, StringFormat=' ({0})'}" FontWeight="Bold" Opacity="0.7" Padding="0,2,2,2"/>
+                                                </StackPanel>
+                                            </Expander.Header>
+                                            <ItemsPresenter Margin="15,0,0,0"/>
+                                        </Expander>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </GroupStyle.ContainerStyle>
+                </GroupStyle>
+            </ListBox.GroupStyle>
+        </ListBox>
         <local:FileInfo Grid.Row="3" Margin="7.5,7.5,0,0" />
         <local:MotionList Grid.Column="2" Grid.Row="2" Grid.RowSpan="2" />
         <local:ScriptList Grid.Column="2" Grid.Row="2" Grid.RowSpan="2" Visibility="Hidden" />
         <local:ClothingTableList Grid.Column="2" Grid.Row="2" Grid.RowSpan="2" Visibility="Hidden" />
+        <DockPanel Grid.Row="4" Grid.ColumnSpan="2" Margin="7.5,0,7.5,0">
+            <Label Content="Weenie Search" DockPanel.Dock="Left" Padding="0,5,5,5"/>
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Margin="5,0,0,0">
+                <Label Content="Type" VerticalAlignment="Center" Padding="0,0,5,0"/>
+                <ToggleButton Name="TypeFilterToggle" Width="120" HorizontalContentAlignment="Left" Content="All Types" ToolTipService.ShowOnDisabled="True">
+                    <ToggleButton.Style>
+                        <Style TargetType="ToggleButton">
+                            <Style.Triggers>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Background" Value="#66808080"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ToggleButton.Style>
+                </ToggleButton>
+                <Popup Name="TypeFilterPopup" PlacementTarget="{Binding ElementName=TypeFilterToggle}" Placement="Bottom"
+                       StaysOpen="False" IsOpen="{Binding IsChecked, ElementName=TypeFilterToggle, Mode=TwoWay}">
+                    <Border Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" BorderBrush="Gray" BorderThickness="1">
+                        <ScrollViewer MaxHeight="300" VerticalScrollBarVisibility="Auto">
+                        <ItemsControl ItemsSource="{Binding TypeFilterOptions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <CheckBox Content="{Binding Name}" IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                              Margin="4,2" Checked="TypeFilterOption_Changed" Unchecked="TypeFilterOption_Changed"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
+                </Popup>
+            </StackPanel>
+            <TextBox Name="SearchBox" VerticalContentAlignment="Center" TextChanged="SearchBox_TextChanged" ToolTipService.ShowOnDisabled="True">
+                <TextBox.Style>
+                    <Style TargetType="TextBox">
+                        <Style.Triggers>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Background" Value="#66808080"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
+        </DockPanel>
     </Grid>
 </UserControl>

--- a/ACViewer/View/FileExplorer.xaml.cs
+++ b/ACViewer/View/FileExplorer.xaml.cs
@@ -7,6 +7,9 @@ using System.Runtime.CompilerServices;
 using System.Media;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Threading;
 
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
@@ -17,6 +20,27 @@ using ACViewer.FileTypes;
 
 namespace ACViewer.View
 {
+    /// <summary>
+    /// One checkable entry in the Weenie Type multi-select popup
+    /// </summary>
+    public class TypeFilterOption : INotifyPropertyChanged
+    {
+        public string Name { get; set; }
+
+        private bool _isSelected;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                _isSelected = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+
     /// <summary>
     /// Interaction logic for FileType.xaml
     /// </summary>
@@ -55,12 +79,45 @@ namespace ACViewer.View
             }
         }
 
+        private List<Data.WeenieSearchEntry> _searchResults { get; set; }
+
+        public List<Data.WeenieSearchEntry> SearchResults
+        {
+            get => _searchResults;
+            set
+            {
+                _searchResults = value;
+                NotifyPropertyChanged("SearchResults");
+            }
+        }
+
+        private List<TypeFilterOption> _typeFilterOptions { get; set; } = new List<TypeFilterOption>();
+
+        public List<TypeFilterOption> TypeFilterOptions
+        {
+            get => _typeFilterOptions;
+            set
+            {
+                _typeFilterOptions = value;
+                NotifyPropertyChanged("TypeFilterOptions");
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
+
+        private readonly DispatcherTimer _searchDebounce;
 
         public FileExplorer()
         {
             InitializeComponent();
             Instance = this;
+
+            _searchDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(200) };
+            _searchDebounce.Tick += (s, e) =>
+            {
+                _searchDebounce.Stop();
+                ExecuteSearch();
+            };
 
             FileTypes = new List<Entity.FileType>()
             {
@@ -111,6 +168,16 @@ namespace ACViewer.View
             History = new History();
 
             DataContext = this;
+
+            SetSearchControlsEnabled(false, "Weenie search requires the ace_world database");
+        }
+
+        private void SetSearchControlsEnabled(bool enabled, string tooltip = null)
+        {
+            SearchBox.IsEnabled = enabled;
+            TypeFilterToggle.IsEnabled = enabled;
+            SearchBox.ToolTip = tooltip;
+            TypeFilterToggle.ToolTip = tooltip;
         }
 
         private void FileType_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -198,6 +265,120 @@ namespace ACViewer.View
                 ReadCellFile(fileID);
         // Update navigation buttons after any navigation
         MainWindow?.menuMain?.UpdateNavigationButtons();
+        }
+
+        // minimum characters before actually running a search -- a 1-character term matches
+        // thousands of the ~44k indexed weenies, which is the expensive case to sort/group
+        private const int MinSearchLength = 2;
+
+        private void SearchBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(SearchBox.Text))
+            {
+                // clearing the box should feel instant -- don't wait on the debounce timer.
+                // ExecuteSearch (not an immediate hide) since a type filter alone can still show results
+                _searchDebounce.Stop();
+                ExecuteSearch();
+                return;
+            }
+
+            // debounce -- running the full search+regroup on every single keystroke is what was
+            // causing the multi-second lag while typing, since each intermediate 1-2 character
+            // prefix matches thousands of entries. Only search once typing pauses.
+            _searchDebounce.Stop();
+            _searchDebounce.Start();
+        }
+
+        private void TypeFilterOption_Changed(object sender, RoutedEventArgs e)
+        {
+            var selected = TypeFilterOptions.Where(o => o.IsSelected).Select(o => o.Name).ToList();
+
+            TypeFilterToggle.Content = selected.Count == 0 ? "All Types" :
+                selected.Count == 1 ? selected[0] :
+                $"{selected.Count} types";
+
+            // react immediately -- unlike typing, a checkbox toggle isn't a rapid-fire event
+            // stream, so there's no need to debounce it
+            _searchDebounce.Stop();
+            ExecuteSearch();
+        }
+
+        private void ExecuteSearch()
+        {
+            var query = SearchBox.Text?.Trim() ?? "";
+            var hasQuery = query.Length >= MinSearchLength;
+
+            var selectedTypes = TypeFilterOptions.Where(o => o.IsSelected).Select(o => o.Name).ToList();
+            var hasTypeFilter = selectedTypes.Count > 0;
+
+            if (!hasQuery && !hasTypeFilter)
+            {
+                SearchResultsList.Visibility = Visibility.Collapsed;
+                Files.Visibility = Visibility.Visible;
+                return;
+            }
+
+            if (!Data.WeenieSearchIndex.IsLoaded)
+            {
+                MainWindow.Status.WriteLine("Weenie search index isn't ready yet -- is the ace_world database connected?");
+                return;
+            }
+
+            SearchResultsList.Visibility = Visibility.Visible;
+            Files.Visibility = Visibility.Collapsed;
+
+            SearchResults = Data.WeenieSearchIndex.Search(hasQuery ? query : null, hasTypeFilter ? selectedTypes : null);
+
+            // group by resolved Setup dat ID -- many WCIDs commonly share one asset (e.g. a
+            // Baby/Chief/Elder tier of the same creature), so this collapses those into one
+            // header instead of repeating a near-identical row per WCID
+            var grouped = new ListCollectionView(SearchResults);
+            grouped.GroupDescriptions.Add(new PropertyGroupDescription(nameof(Data.WeenieSearchEntry.SetupIdHex)));
+
+            SearchResultsList.ItemsSource = grouped;
+        }
+
+        /// <summary>
+        /// Called by Server.TryPrimeDatabase()/RefreshWeenieSearchIndex() once the search index has
+        /// finished (or failed to) build
+        /// </summary>
+        public void OnSearchIndexLoaded(bool success)
+        {
+            SearchBox.Text = "";
+
+            if (!success)
+            {
+                SetSearchControlsEnabled(false, "Weenie search unavailable -- check the ace_world database connection");
+                return;
+            }
+
+            SetSearchControlsEnabled(true);
+
+            TypeFilterOptions = Data.WeenieSearchIndex.AvailableWeenieTypes
+                .Select(t => new TypeFilterOption { Name = t })
+                .ToList();
+            TypeFilterToggle.Content = "All Types";
+        }
+
+        private void SearchResults_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var entry = (Data.WeenieSearchEntry)SearchResultsList.SelectedItem;
+            if (entry == null) return;
+
+            Finder.Navigate(entry.SetupId.ToString("X8"));
+        }
+
+        private void GroupHeader_Click(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement fe && fe.DataContext is CollectionViewGroup group)
+            {
+                // reuse the already-working leaf-row selection path (SearchResults_SelectionChanged)
+                // rather than calling Finder.Navigate directly, since there's no obviously safer way
+                // to jump straight to the group's shared asset than picking a representative member
+                var firstEntry = group.Items.OfType<Data.WeenieSearchEntry>().FirstOrDefault();
+                if (firstEntry != null)
+                    SearchResultsList.SelectedItem = firstEntry;
+            }
         }
 
         public void ReadCellFile(uint fileID)

--- a/ACViewer/View/MainMenu.xaml
+++ b/ACViewer/View/MainMenu.xaml
@@ -52,6 +52,7 @@
             <MenuItem Header="_Server">
                 <MenuItem Header="Load _Instances" Click="LoadInstances_Click" x:Name="optionLoadInstances"/>
                 <MenuItem Header="Load _Encounters" Click="LoadEncounters_Click" x:Name="optionLoadEncounters"/>
+                <MenuItem Header="_Refresh Weenie Search Index" Click="RefreshWeenieSearchIndex_Click"/>
             </MenuItem>
             <MenuItem Header="_View">
                 <MenuItem Header="_World Map" Click="WorldMap_Click" />

--- a/ACViewer/View/MainMenu.xaml.cs
+++ b/ACViewer/View/MainMenu.xaml.cs
@@ -89,7 +89,7 @@ namespace ACViewer.View
                 var portalFiles = DatManager.PortalDat.AllFiles.Count;
 
                 MainWindow.Status.WriteLine($"CellFiles={cellFiles}, PortalFiles={portalFiles}");*/
-                MainWindow.Status.WriteLine(runWorkerCompletedEventArgs.Error?.Message ?? "Done");
+                MainWindow.Status.WriteLine(runWorkerCompletedEventArgs.Error?.Message ?? "Dat files loaded");
                     
 
                 if (DatManager.CellDat == null || DatManager.PortalDat == null) return;
@@ -310,6 +310,11 @@ namespace ACViewer.View
         private void LoadInstances_Click(object sender, RoutedEventArgs e)
         {
             ToggleInstances();
+        }
+
+        private void RefreshWeenieSearchIndex_Click(object sender, RoutedEventArgs e)
+        {
+            Server.RefreshWeenieSearchIndex();
         }
 
         public static void ToggleInstances(bool updateConfig = true)


### PR DESCRIPTION
Lets users search for a creature/object by name or description instead of browsing raw dat file IDs. Builds a cached, in-memory index from ace_world (weenie names, descriptions, and CreatureType/HeritageGroup/etc. category data), ranked so real name matches outrank incidental text mentions, with a multi-select Weenie Type filter and results grouped by shared dat asset.

The index is cached to disk and refreshed automatically when the database's data changes (or manually via Server > Refresh Weenie Search Index), so normal startup doesn't re-query the full weenie table.

Falls back gracefully with no ace_world connection: dat browsing is unaffected and the search controls are simply disabled with an explanatory tooltip. Also hardens database connection failures (bad config, auth failure) to log clearly instead of risking a silent crash, and adds a top-level unhandled exception handler as a general safety net.